### PR TITLE
feat(produtos): Integração arquitetural Spring-JavaFX concluída.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.16.1</version> 
+		</dependency>
 
 		<!-- JavaFX Dependencies (NEW) -->
 		<dependency>

--- a/src/main/java/com/example/pdv_galeteria/Frontend/JavaFxApplication.java
+++ b/src/main/java/com/example/pdv_galeteria/Frontend/JavaFxApplication.java
@@ -1,0 +1,45 @@
+package com.example.pdv_galeteria.Frontend;
+
+import com.example.pdv_galeteria.Frontend.Models.StageReadyEvent;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+import java.io.File;
+import java.io.IOException;
+
+@Component
+public class JavaFXApplication implements ApplicationListener<StageReadyEvent> {
+
+    private final ApplicationContext applicationContext;
+
+    public JavaFXApplication(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public void onApplicationEvent(StageReadyEvent event) {
+        try {
+            Stage stage = event.getStage();
+        
+            File fxmlFile = new File("src/main/java/com/example/pdv_galeteria/Frontend/views/TelaLogin.fxml");
+            FXMLLoader fxmlLoader = new FXMLLoader(fxmlFile.toURI().toURL());
+            
+            fxmlLoader.setControllerFactory(applicationContext::getBean); 
+
+            Parent root = fxmlLoader.load();
+            
+            stage.setTitle("Galeteria do Irmão - Login");
+            stage.setScene(new Scene(root, 1350, 700));
+            stage.setResizable(true);
+            stage.setMaximized(true);
+            stage.show();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Falha ao carregar a tela de login (FXML).", e);
+        }
+    }
+}

--- a/src/main/java/com/example/pdv_galeteria/Frontend/Models/Main.java
+++ b/src/main/java/com/example/pdv_galeteria/Frontend/Models/Main.java
@@ -1,27 +1,31 @@
 package com.example.pdv_galeteria.Frontend.Models;
 
-import java.io.File;
-
+import com.example.pdv_galeteria.PdvGaleteriaApplication;
 import javafx.application.Application;
-import javafx.fxml.FXMLLoader;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
+import javafx.application.Platform;
 import javafx.stage.Stage;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ApplicationContext;
 
 public class Main extends Application {
+
+    private ApplicationContext applicationContext;
+
+    @Override
+    public void init() throws Exception {
+        applicationContext = new SpringApplicationBuilder(PdvGaleteriaApplication.class)
+                .run(getParameters().getRaw().toArray(new String[0]));
+    }
+
     @Override
     public void start(Stage primaryStage) throws Exception {
-        File fxmlFile = new File("src/main/java/com/example/pdv_galeteria/Frontend/views/TelaLogin.fxml");
-        System.out.println("Carregando: " + fxmlFile.getAbsolutePath());
-        System.out.println("Arquivo existe: " + fxmlFile.exists());
+         applicationContext.publishEvent(new StageReadyEvent(primaryStage));
+    }
 
-        Parent root = FXMLLoader.load(fxmlFile.toURI().toURL());
-        primaryStage.setTitle("Galeteria do Irmão - Login");
-        primaryStage.setScene(new Scene(root, 1350, 700));
-        primaryStage.setResizable(true);
-        primaryStage.setMaximized(true);
-
-        primaryStage.show();
+    @Override
+    public void stop() throws Exception {
+        ((Stage) applicationContext).close();
+        Platform.exit();
     }
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/pdv_galeteria/Frontend/Models/StageReadyEvent.java
+++ b/src/main/java/com/example/pdv_galeteria/Frontend/Models/StageReadyEvent.java
@@ -1,0 +1,17 @@
+package com.example.pdv_galeteria.Frontend.Models;
+
+import javafx.stage.Stage;
+import org.springframework.context.ApplicationEvent;
+
+public class StageReadyEvent extends ApplicationEvent {
+    private final Stage stage;
+
+    public StageReadyEvent(Stage stage) {
+        super(stage);
+        this.stage = stage;
+    }
+
+    public Stage getStage() {
+        return stage;
+    }
+}


### PR DESCRIPTION
Principais Mudanças:

Injeção Direta: Os controladores Front-end (JavaFX) agora injetam e utilizam diretamente os serviços Spring (ex: ProdutoService), eliminando a necessidade de chamadas HTTP internas (@RestControllers).

Fluxo de Produtos: Os controladores necessários (CadastrarProdutoController, TelaProdutosController) foram adicionados e configurados para chamar o ProdutoService.salvar() e ProdutoService.listarTodos()